### PR TITLE
Timers can run in the background

### DIFF
--- a/src/Timebox.js
+++ b/src/Timebox.js
@@ -3,9 +3,24 @@ import Timer from './Timer';
 export default class Timebox {
   constructor({ el, timers=[] }) {
     this.el = el;
+
     this.timers = timers.map(options => {
       const timer = new Timer(options);
       this.el.appendChild(timer.el);
-    })
+      return timer;
+    });
+
+    this.lastUpdate = new Date().getTime();
+
+    // every 100 ms, update timers
+    this.timerInterval = setInterval(() => {
+      this.updateTimers()
+    }, 100);
+  }
+
+  updateTimers() {
+    const timeDifference = new Date().getTime() - this.lastUpdate;
+    this.timers.map(timer => timer.update(timeDifference))
+    this.lastUpdate = new Date().getTime();
   }
 }

--- a/src/Timer.js
+++ b/src/Timer.js
@@ -5,12 +5,13 @@ export default class Timer {
   constructor(options) {
     const timer = this;
 
+    this.isPlaying = false;
+
     this.label = options.label;
     this.duration = options.duration;
     this.warning = options.warning;
 
-    this.remaining = this.duration;
-    this.elapsed = 0;
+    this.remainingMs = this.duration * 1000;
 
     this.template = `
       <h2 class="label"></h2>
@@ -36,6 +37,14 @@ export default class Timer {
     return this;
   }
 
+  get remaining() {
+    return Math.ceil(this.remainingMs / 1000);
+  }
+
+  get elapsed() {
+    return this.duration - this.remaining;
+  }
+
   render() {
     this.el.querySelector('.label').innerHTML = this.label;
     this.renderElapsed(0);
@@ -51,24 +60,29 @@ export default class Timer {
     this.el.querySelector('.elapsed').innerHTML = formatTime(time);
   }
 
-  stepTimer() {
-    this.renderRemaining(this.remaining);
-    this.renderElapsed(this.elapsed);
-    if(this.remaining > 0) {
+  update(timeDifference) {
+    if (!this.isPlaying) {
+      return;
+    }
+
+    this.remainingMs -= timeDifference;
+
+    if(this.remainingMs > 0) {
       if(this.warning && this.remaining <= this.warning) {
         this.el.classList.add('warning');
       }
-      this.elapsed++;
-      this.remaining--;
-      this.t = setTimeout(this.stepTimer.bind(this), 1000);
       this.isPlaying = true;
       this.el.classList.add('is-playing');
     } else {
+      this.remainingMs = 0;
       this.el.classList.remove('warning');
       this.el.classList.add('stop');
       this.isPlaying = false;
       this.el.classList.remove('is-playing');
     }
+
+    this.renderRemaining(this.remaining);
+    this.renderElapsed(this.elapsed);
   }
 
   toggleFocus() {
@@ -82,9 +96,8 @@ export default class Timer {
     if(this.isPlaying) {
       this.isPlaying = false;
       this.el.classList.remove('is-playing');
-      clearTimeout(this.t);
     } else {
-      this.stepTimer();
+      this.isPlaying = true;
     }
   }
 


### PR DESCRIPTION
For inspiration for this approach see 
https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/share/goodie/timer/timer.js

The issue was that if you went to a different tab from the timers, 
eventually they seemed to stop running. It looks like the browser either 
stops or slows down setTimeouts.

So instead, now a timed loop is running to govern all timers, and 
whenever that updates it passes the amount of time passed since the last 
update so the timers can remain accurate even if they are getting 
updated less frequently.